### PR TITLE
solucionada errata del bundle

### DIFF
--- a/PrototipoVPC/src/gui/dialog/ScaleDialog.java
+++ b/PrototipoVPC/src/gui/dialog/ScaleDialog.java
@@ -59,7 +59,7 @@ public class ScaleDialog {
         valuesSpinners[1] = new JSpinner(new SpinnerNumberModel(image.getHeight(),MIN_VAL,MAX_VAL,STEP_SIZE)); 
         
         // JRadioButtons para seleccionar
-        percentButton = new JRadioButton(I18n.getString("Dialog.ScalePercent"));
+        percentButton = new JRadioButton(I18n.getString("DialogScale.Percent"));
         percentButton.addActionListener(new ActionListener() { 
             public void actionPerformed(ActionEvent e) { 
                 for (int i=0; i<2; i++) {


### PR DESCRIPTION
No se podía mostrar el diálogo de "Escala" porque había una errata con el nombre de una traducción.

Comprueba, mezcla y ya nos vemos :smiley: 
